### PR TITLE
Add waters_to_retain as command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ mol_file: ligand.mol
 ##### Preparing system for amber
 
 Script to prepare the prot-chunk system using open duck, but to launch the simulations in amber
-If you want to keep structural waters, have a file with them called "waters_to_retain.pdb"
+If you want to keep structural waters, pass a file containing them using the `--waters-to-retain`
+parameter, or create a file called "waters_to_retain.pdb", which OpenDuCK checks by default.
 
 ```{bash}
 conda activate openduck_latest

--- a/duck/steps/parametrize.py
+++ b/duck/steps/parametrize.py
@@ -22,7 +22,7 @@ def find_box_size(input_file="complex.pdb", add_factor=20):
     return int(val_in_ang.value_in_unit(unit.angstrom)) + 1
 
 
-def prepare_system(ligand_file, protein_file, forcefield_str="amber99sb.xml", water_ff_str = 'tip3p', hmr=False, small_molecule_ff = 'SMIRNOFF', box_buffer_distance = 10, ionicStrength = 0.1):
+def prepare_system(ligand_file, protein_file, forcefield_str="amber99sb.xml", water_ff_str = 'tip3p', hmr=False, small_molecule_ff = 'SMIRNOFF', box_buffer_distance = 10, ionicStrength = 0.1, waters_to_retain="waters_to_retain.pdb"):
 
     #Do not put ESPALOMA yet, as it is not on the conda release of openmmforcefields yet, The function is already prepared
     #FF_generators = {'SMIRNOFF': generateSMIRNOFFStructureRDK, 'GAFF2': generateGAFFStructureRDK, 'ESPALOMA': generateEspalomaFFStructureRDK}
@@ -50,9 +50,9 @@ def prepare_system(ligand_file, protein_file, forcefield_str="amber99sb.xml", wa
         protein.topology, protein_system, protein.positions
     )
     protein_pmd.save("protein_prepared.pdb", overwrite=True)
-    if Path("waters_to_retain.pdb").exists():
-        print(f'waters retained from {Path("waters_to_retain.pdb")}')
-        waters_retained = parmed.load_file("waters_to_retain.pdb")
+    if Path(waters_to_retain).exists():
+        print(f'waters retained from {Path(waters_to_retain)}')
+        waters_retained = parmed.load_file(waters_to_retain)
         prot_lig_pmd = protein_pmd + ligand_pmd + waters_retained
     else:
         prot_lig_pmd = protein_pmd + ligand_pmd
@@ -133,3 +133,4 @@ if __name__ == "__main__":
     ligand_file = sys.argv[2]
     protein_file = sys.argv[1]
     system = prepare_system(ligand_file, protein_file, hmr=True, water_ff_str='tip3p.xml')
+

--- a/scripts/batch_duck_prepare_for_amber.py
+++ b/scripts/batch_duck_prepare_for_amber.py
@@ -21,11 +21,11 @@ def ligand_string_generator(file):
                 mol = []
                 yield '\n'.join(new_mol)
 
-def prepare_sys_for_amber(ligand_file, protein_file, chunk_file, interaction, HMR,  small_molecule_forcefield='SMIRNOFF', water_ff_str = 'tip3p.xml', forcefield_str='amber99sb.xml', ionic_strength = 0.1, box_buffer_distance = 10):
+def prepare_sys_for_amber(ligand_file, protein_file, chunk_file, interaction, HMR,  small_molecule_forcefield='SMIRNOFF', water_ff_str = 'tip3p.xml', forcefield_str='amber99sb.xml', ionic_strength = 0.1, box_buffer_distance = 10, waters_to_retain="waters_to_retain.pdb"):
     # Parameterize the ligand
     prepare_system(ligand_file, chunk_file, forcefield_str=forcefield_str,
                    hmr=HMR, small_molecule_ff=small_molecule_forcefield, water_ff_str = water_ff_str,
-                   box_buffer_distance = box_buffer_distance, ionicStrength = ionic_strength)
+                   box_buffer_distance = box_buffer_distance, ionicStrength = ionic_strength, waters_to_retain="waters_to_retain.pdb")
     
     # Now find the interaction and save to a file
     results = find_interaction(interaction, protein_file)
@@ -43,7 +43,7 @@ def prepare_sys_for_amber(ligand_file, protein_file, chunk_file, interaction, HM
     write_all_inputs(p[0], p[1:], hmr = HMR)
     write_getWqbValues()
 
-def prepare_ligand_in_folder(ligand_string, lig_indx, protein, chunk, interaction, HMR, base_dir, small_molecule_forcefield = 'SMIRNOFF', water_model = 'tip3p', forcefield = 'amber99sb', ion_strength = 0.1, box_buffer_distance = 10):
+def prepare_ligand_in_folder(ligand_string, lig_indx, protein, chunk, interaction, HMR, base_dir, small_molecule_forcefield = 'SMIRNOFF', water_model = 'tip3p', forcefield = 'amber99sb', ion_strength = 0.1, box_buffer_distance = 10, waters_to_retain='waters_to_retain.pdb'):
 
     os.chdir(base_dir)
 
@@ -59,12 +59,13 @@ def prepare_ligand_in_folder(ligand_string, lig_indx, protein, chunk, interactio
             # Copying files to ligand foldef; ligand and prot
             write_string_to_file(string=ligand_string, file=f'lig_{lig_indx}.mol')
             shutil.copyfile(f'../{protein}', f'./{protein}', follow_symlinks=True)
-            if os.path.isfile('../waters_to_retain.pdb'):
-                shutil.copyfile(f'../waters_to_retain.pdb', f'./waters_to_retain.pdb', follow_symlinks=True)
+            if os.path.isfile(f'../{waters_to_retain}'):
+                shutil.copyfile(f'../{waters_to_retain', f'./{waters_to_retain}', follow_symlinks=True)
 
             prepare_sys_for_amber(f'lig_{lig_indx}.mol', protein, chunk, interaction, HMR,
                                   small_molecule_forcefield=small_molecule_forcefield, water_ff_str=f'{water_model}',
-                                  forcefield_str=f'{forcefield}.xml', ion_strenght = ion_strength, box_buffer_distance = box_buffer_distance)
+                                  forcefield_str=f'{forcefield}.xml', ion_strenght = ion_strength,
+                                  box_buffer_distance = box_buffer_distance, waters_to_retain="waters_to_retain.pdb")
 
     #os.chdir(f'..')
     return(f'Lig_target_{lig_indx} prepared correctly')
@@ -95,7 +96,7 @@ def main():
     parser.add_argument('-pf','--protein-forcefield', default='amber99sb', type=str.lower, help='Protein forcefield to parametrize the chunked protein. Chose form the following: [amber99sb | amber14-all]')
     parser.add_argument('-ion','--ionic-strength', default=0.1, type=float, help='Ionic strength (concentration) of the counter ion salts (Na+/Cl+). Default = 0.1 M')
     parser.add_argument('-b','--solvent-buffer-distance', default=10, type=float, help='Buffer distance between the periodic box and the protein. Default = 10 A')
-
+    parser.add_argument('-water','--waters-to-retain', default='waters_to_retain.pdb', type=str, help='PDB File with structural waters to retain water moleules. Default is waters_to_retain.pdb.')
     
     args = parser.parse_args()
 
@@ -117,7 +118,7 @@ def main():
                           args=(ligand_string, j+1, args.protein, args.chunk,
                                 args.interaction, args.HMR, base_dir,
                                 args.small_molecule_forcefield, args.water_model, args.protein_forcefield,
-                                args.ionic_strength, args.solvent_buffer_distance),
+                                args.ionic_strength, args.solvent_buffer_distance, args.waters_to_retain),
                           callback=log_result,
                           error_callback=handle_error) for j, ligand_string in enumerate(ligand_string_generator(args.ligands))]
     pool.close()

--- a/scripts/duck_prepare_sys_for_amber.py
+++ b/scripts/duck_prepare_sys_for_amber.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('-pf','--protein-forcefield', default='amber99sb', type=str.lower, help='Protein forcefield to parametrize the chunked protein. Chose form the following: [amber99sb | amber14-all]')
     parser.add_argument('-ion','--ionic-strength', default=0.1, type=float, help='Ionic strength (concentration) of the counter ion salts (Na+/Cl+). Default = 0.1 M')
     parser.add_argument('-b','--solvent-buffer-distance', default=10, type=float, help='Buffer distance between the periodic box and the protein. Default = 10 A')
+    parser.add_argument('-water','--waters-to-retain', default='waters_to_retain.pdb', type=str, help='PDB File with structural waters to retain water moleules. Default is waters_to_retain.pdb.')
 
     args = parser.parse_args()
     
@@ -29,7 +30,7 @@ def main():
 
     # Parameterize the ligand
     prepare_system(args.ligand, args.chunk, forcefield_str=f'{args.protein_forcefield}.xml', water_ff_str = f'{args.water_model}',
-                   hmr=args.HMR, small_molecule_ff=args.small_molecule_forcefield,
+                   hmr=args.HMR, small_molecule_ff=args.small_molecule_forcefield, waters_to_retain=args.waters_to_retain,
                    box_buffer_distance = args.solvent_buffer_distance, ionicStrength = args.ionic_strength)
     # Now find the interaction and save to a file
     results = find_interaction(args.interaction, args.protein)


### PR DESCRIPTION
I mistakenly made some DuCK runs without specifying waters; it would be nice for this to be an argument on the command line.