### PR TITLE
Add sdwriter.close() to fix_ligand() function

### DIFF
--- a/duck/steps/parametrize.py
+++ b/duck/steps/parametrize.py
@@ -191,6 +191,7 @@ def fix_ligand(ligand_file, fixed_ligand_file):
     fixed_mol = Chem.AddHs(mol, addCoords=True, onlyOnAtoms=[atom.GetIdx() for atom in mol.GetAtoms() if atom.GetSymbol() == 'C'])
     sdwriter = Chem.SDWriter(fixed_ligand_file)
     sdwriter.write(fixed_mol)
+    sdwriter.close()
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:


### PR DESCRIPTION
I discovered that if this line is missing, the coordinates get written to the SDF, but none of the properties 😅 