### PR TITLE
Add `--local-minimization` flag

### DIFF
--- a/duck/steps/minimize.py
+++ b/duck/steps/minimize.py
@@ -1,0 +1,14 @@
+import subprocess
+from shutil import which
+
+def run_minimization():
+    # default to pmemd; if it doesn't exist fall back to sander, which should be installed as a dependency of AmberTools
+    engine = which('pmemd') or which('sander')
+    if not engine:
+        raise Exception("Neither pmemd nor sander are installed. AmberTools should be installed as an OpenDuCK dependency; check this is the case.")
+    print(f'running minimization with {engine}...')
+    cmd_line = [engine, "-O", "-i", "1_min.in", "-o", "min.out", "-p", "system_complex.prmtop", "-c", "system_complex.inpcrd", "-r", "min.rst", "-ref", "system_complex.inpcrd"]
+    process = subprocess.run(cmd_line, capture_output=True)
+    if process.returncode != 0:
+        raise Exception(f"{engine} run failed with the following command: {' '.join(cmd_line)}, the following stdout: {process.stdout}, the following stderr: {process.stderr}, and the following exit code {process.returncode}",)
+

--- a/duck/templates/queueing_templates/commands.txt
+++ b/duck/templates/queueing_templates/commands.txt
@@ -5,7 +5,7 @@ min_wqb={wqb_threshold}
     
 #### Runing Duck ####
 # Minimization
-pmemd.cuda -O -i 1_min.in -o min.out -p {top} -c system_complex.inpcrd -r min.rst -ref system_complex.inpcrd
+{comment}pmemd.cuda -O -i 1_min.in -o min.out -p {top} -c system_complex.inpcrd -r min.rst -ref system_complex.inpcrd
 
 # Centering box to allow iwrap, not being centered to 0,0,0 bricks the system when using iwrap and nmr restraints together
 echo -e "trajin min.rst\ncenter\ntrajout min.rst\nrun\nquit" | cpptraj -p {top}
@@ -38,4 +38,3 @@ for ((i=1;i<=$replicas;++i)); do
    check_WQB $min_wqb
 
 done
-    

--- a/duck/utils/amber_inputs.py
+++ b/duck/utils/amber_inputs.py
@@ -48,7 +48,7 @@ Methods:
     copy_getWqbValues_script(): Copies the getWqbValues.py script from the queue templates directory to the current working directory.
     write_queue_file(kind): Generates a queue file with the given kind (template) and writes it to disk.
     """
-    def __init__(self, wqb_threshold=0, replicas=20, hmr=True, array_limit=False, keep_intermediate_files=False):
+    def __init__(self, wqb_threshold=0, replicas=20, hmr=True, array_limit=False, keep_intermediate_files=False, local_minimization=False):
         '''
         Initialize the Queue_templates class.
 
@@ -62,7 +62,8 @@ Methods:
         self.replicas = replicas
         self.hmr = hmr
         self.array_limit = array_limit
-        
+        self.local_minimization = local_minimization
+
         if hmr: self.top = 'HMR_system_complex.prmtop'
         else: self.top = 'system_complex.prmtop'
         
@@ -94,7 +95,7 @@ Methods:
         Private method to read command template files
         '''
         cmd_template = self._read_template('commands.txt')
-        return cmd_template.format(replicas=self.replicas, wqb_threshold = self.wqb_threshold, top = self.top, i='{i}')
+        return cmd_template.format(replicas=self.replicas, wqb_threshold = self.wqb_threshold, comment='#' if self.local_minimization else '', top = self.top, i='{i}')
     
     def _get_functions_string(self):
         '''


### PR DESCRIPTION
This allows the user to run minimization locally as part of the `amber-prepare` subcommand, rather than including it in the queue template which is sent to a remote resource. The reason is that in our pipeline we would like to be able to check the minimized structure before performing full dynamic undocking runs