### PR TITLE
Bugfix: check if LIG_TARGET var is set before copying working dir there

### DIFF
--- a/duck/templates/queueing_templates/functions.txt
+++ b/duck/templates/queueing_templates/functions.txt
@@ -47,7 +47,11 @@ check_WQB(){{
    are_we_above_the_limit=$(echo "$lowest_wqb < $wqb_limit" | bc )
    if [ "$are_we_above_the_limit" == "1" ]; then
       echo "Wqb lower than ${wqb_limit}, stoping DUck run"
-      cp -r ./* $LIG_TARGET/
+
+      # check if LIG_TARGET is set; if so, copy files there
+      if [ $LIG_TARGET ]; then
+          cp -r ./* $LIG_TARGET/
+      fi
       exit 
    fi
 }}


### PR DESCRIPTION
If the environment variable `$LIG_TARGET` isn't set openduck tries to copy everything to `/` and then you get errors like

```
cp: cannot create regular file '/1_min.in': Permission denied
cp: cannot create regular file '/2_heating150.in': Permission denied
cp: cannot create regular file '/2_heating150.out': Permission denied
...
```

The change here only tries to copy files after checking `$LIG_TARGET` is set.