### PR TITLE
Add batch support and SLURM launcher for OpenMM backend

### DIFF
--- a/duck/utils/analysis_and_report.py
+++ b/duck/utils/analysis_and_report.py
@@ -289,7 +289,7 @@ def get_expavg_FD_df(work_df, T=300, calculate_FD=True):
     final_df = pd.DataFrame(columns=['expavg', 'sqrtMSE', 'MSE', 'Bj', 'v', 'av', 'ai', 'Wdis', 'avg', 'variance', 'FD', 'sqrtMSE_FD'],
                             index = work_df.index)
     t_work = work_df.T
-    expBwork  = t_work.applymap(lambda x : exp(x*(-B)))
+    expBwork  = t_work.map(lambda x : np.exp(x*(-B)))
     N = len(work_df.columns) # Should be 5000 for DUck
 
     for rc, work_step in work_df.iterrows():
@@ -301,7 +301,7 @@ def get_expavg_FD_df(work_df, T=300, calculate_FD=True):
         variance = np.var(work_step)
 
         #Boltzman average for the step
-        expavg   = (-log(np.mean(expBwork.loc[:,rc])))/B
+        expavg   = (-np.log(np.mean(expBwork.loc[:,rc])))/B
         if calculate_FD: # I have added the option to skip it, as it was giving some overflow float problems with very big dissipations during sampling
             # Other parameter for the fluctuation dissipation formula (applied to the Boltzmann avg)
             # Dissipated work due to heat loss, Wdis = T*dS-dQ if Wdis >=0
@@ -309,8 +309,8 @@ def get_expavg_FD_df(work_df, T=300, calculate_FD=True):
             if np.isnan(Wdis) or Wdis < 0.02: # for very small Wdis we can neglect it
                 ai, av = 1, 1
             else:
-                ai = float(log(30*Wdis*B))/float(log(15*(exp(2*B*Wdis)-1)))
-                av=float(log(100*Wdis*B))/float(log(50*(exp(2*B*Wdis)-1)))
+                ai = float(np.log(30*Wdis*B))/float(np.log(15*(np.exp(2*B*Wdis)-1)))
+                av = float(np.log(100*Wdis*B))/float(np.log(50*(np.exp(2*B*Wdis)-1)))
             try:
                 Bj = Wdis/N**ai
                 v = variance/N**av

--- a/openDUck_singularity.def
+++ b/openDUck_singularity.def
@@ -14,6 +14,7 @@ From: ubuntu:22.04
     conda init
     conda install python=3.9
     conda install -c conda-forge mamba
+    conda install -c conda-forge ncurses
     mamba install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5 openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
     pip install "openduck @ git+https://github.com/CBDD/openduck.git"
     pip cache purge

--- a/openDUck_singularity.def
+++ b/openDUck_singularity.def
@@ -1,0 +1,29 @@
+Bootstrap: docker
+From: ubuntu:22.04
+
+%post
+    apt-get update
+    export DEBIAN_FRONTEND=noninteractive
+    cd /opt/
+    apt-get -y install git wget g++ locales
+    locale-gen en_US.UTF-8
+    update-locale LANG=en_US.UTF-8
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+    bash ~/miniconda.sh -b -p /opt/miniconda
+    eval "$(/opt/miniconda/bin/conda shell.bash hook)"
+    conda init
+    conda install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5  openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
+    pip install 'openduck @ git+https://github.com/CBDD/openduck.git'
+    pip cache purge
+    conda clean -a -y
+    apt-get clean
+
+%environment
+    export PATH=/opt/miniconda/bin/:$PATH
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
+    export LC_ALL=en_US.UTF-8
+
+%labels
+    AUTHOR Jochem Nelen (jnelen@ucam.edu)
+    Version v1

--- a/openDUck_singularity.def
+++ b/openDUck_singularity.def
@@ -12,8 +12,10 @@ From: ubuntu:22.04
     bash ~/miniconda.sh -b -p /opt/miniconda
     eval "$(/opt/miniconda/bin/conda shell.bash hook)"
     conda init
-    conda install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5  openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
-    pip install 'openduck @ git+https://github.com/CBDD/openduck.git'
+    conda install python=3.9
+    conda install -c conda-forge mamba
+    mamba install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5  openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
+    pip install "openduck @ git+https://github.com/CBDD/openduck.git"
     pip cache purge
     conda clean -a -y
     apt-get clean

--- a/openDUck_singularity.def
+++ b/openDUck_singularity.def
@@ -14,7 +14,7 @@ From: ubuntu:22.04
     conda init
     conda install python=3.9
     conda install -c conda-forge mamba
-    mamba install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5  openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
+    mamba install numpy=1.23.5 yank=0.25.2 pdbfixer=1.7 openff-toolkit=0.9.0 parmed=3.4.3 cudatoolkit=11.7.0 openmm=7.5 openmmforcefields=0.9.0 ambertools=22.0 seaborn=0.12 -c conda-forge -c defaults
     pip install "openduck @ git+https://github.com/CBDD/openduck.git"
     pip cache purge
     conda clean -a -y

--- a/scripts/job_launcher_openDUck.py
+++ b/scripts/job_launcher_openDUck.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+OpenDUck SLURM Job Generator
+-----------------------------
+Created on Thu Apr 10 11:35:19 2025
+Author: Jochem Nelen (jnelen@ucam.edu)
+
+This script prepares and launches SLURM jobs for OpenDUck docking simulations.
+It batches ligands into jobs, writes input SDFs and YAML configs, and constructs
+job scripts with SLURM directives based on user parameters.
+"""
+
+import argparse
+import glob
+import logging
+import shutil
+import sys
+import datetime
+import yaml
+import os
+import subprocess
+
+from pathlib import Path
+from typing import Tuple, List, Dict
+
+from rdkit import Chem
+
+# Set up basic logging configuration
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse command-line arguments for the SLURM job generator.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="An automatic SLURM launcher for OpenDUck calculations."
+    )
+
+    # Required arguments
+    parser.add_argument(
+        "-l",
+        "--ligand",
+        type=Path,
+        required=True,
+        help="Path to ligand (SDF file or directory).",
+    )
+    parser.add_argument(
+        "-p",
+        "--protein",
+        type=Path,
+        required=True,
+        help="Path to the receptor protein .pdb file.",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, required=True, help="Output base directory."
+    )
+
+    # SLURM settings
+    slurm_group = parser.add_argument_group("SLURM Settings")
+    slurm_group.add_argument(
+        "--time",
+        "-t",
+        "-tj",
+        default="",
+        help="Max runtime (e.g., 01:00:00)",
+    )
+    slurm_group.add_argument(
+        "--queue",
+        "-qu",
+        type=str,
+        default="",
+        help="Queue/partition to submit to.",
+    )
+    slurm_group.add_argument(
+        "--mem",
+        "-m",
+        default="4G",
+        help="Memory per job (default: 4G).",
+    )
+    slurm_group.add_argument(
+        "--gpu",
+        "-gpu",
+        "--GPU",
+        action="store_true",
+        default=False,
+        help="Use GPU.",
+    )
+    slurm_group.add_argument(
+        "--cores",
+        "-c",
+        type=int,
+        default=None,
+        help="Cores per job (default: 1 w/ GPU, else 8).",
+    )
+    slurm_group.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=-1,
+        help="Number of jobs (default: one per compound).",
+    )
+
+    # OpenDUck protocol settings
+    duck_group = parser.add_argument_group("OpenDUck Protocol Settings")
+    duck_group.add_argument(
+        "--interaction",
+        type=str,
+        required=True,
+        help="Interaction atom (e.g., _LEU_31_N).",
+    )
+    duck_group.add_argument(
+        "--do-chunk",
+        action="store_true",
+        help="Enable receptor chunking.",
+    )
+    duck_group.add_argument(
+        "--cutoff",
+        type=float,
+        default=9.0,
+        help="Chunking cutoff distance (Angstroms). Default: 9.0A",
+    )
+    duck_group.add_argument(
+        "--ionic-strength",
+        type=float,
+        default=0.10,
+        help="Ionic strength (concentration) of the counter ion salts (Na+/Cl-). Default = 0.1 M",
+    )
+    duck_group.add_argument(
+        "--ignore-buffers",
+        action="store_true",
+        help="Do not remove buffers (solvent, ions etc.)",
+    )
+    duck_group.add_argument(
+        "--small-molecule-forcefield",
+        type=str,
+        choices=["gaff2", "smirnoff"],
+        default="gaff2",
+        help="Small molecule forcefield (default: gaff2)",
+    )
+    duck_group.add_argument(
+        "--protein-forcefield",
+        type=str,
+        choices=["amber99sb", "amber14-all"],
+        default="amber14-all",
+        help="Protein forcefield (default: amber14-all)",
+    )
+    duck_group.add_argument(
+        "--water-model",
+        type=str,
+        choices=["tip3p", "spce"],
+        default="tip3p",
+        help="Water model (default: tip3p)",
+    )
+    duck_group.add_argument(
+        "--hmr",
+        "--HMR",
+        dest="HMR",
+        action="store_true",
+        help="Enable hydrogen mass repartitioning (HMR).",
+    )
+    duck_group.add_argument(
+        "--smd-cycles",
+        type=int,
+        default=10,
+        help="Number of SMD cycles (default: 10)",
+    )
+    duck_group.add_argument(
+        "--wqb-threshold",
+        type=float,
+        default=None,
+        help="WQB threshold (default: None, no threshold)",
+    )
+    duck_group.add_argument(
+        "--fix-ligand",
+        action="store_true",
+        help="Apply simple fixes for the ligand: assign correct charges on tetravalent nitrogens and add missing hydrogen atoms.",
+    )
+
+    return parser.parse_args()
+
+
+def process_sdf(ligand_path: Path) -> Tuple[Dict[str, Chem.Mol], int]:
+    """
+    Parse molecules from a single SDF file.
+
+    Args:
+        ligand_path (Path): Path to the SDF file.
+
+    Returns:
+        Tuple[Dict[str, Chem.Mol], int]: A dictionary mapping molecule names to RDKit molecule objects,
+            and a count of invalid molecules.
+    """
+    mol_dict: Dict[str, Chem.Mol] = {}
+    invalid_mols: int = 0
+    suppl = Chem.SDMolSupplier(str(ligand_path), removeHs=False)
+
+    for mol in suppl:
+        if mol is None:
+            invalid_mols += 1
+            continue
+
+        if mol.HasProp("_Name") and mol.GetProp("_Name").strip():
+            mol_name = mol.GetProp("_Name")
+        else:
+            smiles = Chem.MolToSmiles(mol)
+            mol_name = f"mol_{smiles}"
+            mol.SetProp("_Name", mol_name)
+
+        mol_dict[mol_name] = mol
+
+    return mol_dict, invalid_mols
+
+
+def build_slurm_flag(flag_name: str, value: str, prefix: str = "--") -> str:
+    """
+    Return a formatted SLURM flag string if a value is provided, else returns an empty string.
+
+    Args:
+        flag_name (str): The flag's name.
+        value (str): The flag's value.
+        prefix (str): Prefix for the flag (default is '--').
+
+    Returns:
+        str: Formatted flag string or empty if value is empty.
+    """
+    return f"{prefix}{flag_name} {value}" if value else ""
+
+
+def prepare_output_directory(base_output_path: Path) -> Path:
+    """
+    Prepare the output directory by appending a timestamp. If the directory already exists,
+    prompt the user to remove it.
+
+    Args:
+        base_output_path (Path): The base output directory provided by the user.
+
+    Returns:
+        Path: The prepared output directory path.
+    """
+    date_str = datetime.datetime.now().strftime("%Y_%m_%d")
+    output_dir = base_output_path.parent / f"{base_output_path.name}_{date_str}"
+
+    if output_dir.exists():
+        logging.info("The directory '%s' already exists.", output_dir)
+        answer = input("Do you want to remove it? (y/n): ").strip().lower()
+        while answer not in {"y", "n", "yes", "no"}:
+            answer = input("Please enter y(es) or n(o): ").strip().lower()
+        if answer in {"y", "yes"}:
+            shutil.rmtree(output_dir)
+            logging.info("Removed existing directory: %s", output_dir)
+        else:
+            logging.error("Operation cancelled by user.")
+            sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logging.info("Created output directory: %s", output_dir)
+    return output_dir
+
+
+def batch_mols(molecules: List[str], num_jobs: int) -> List[List[str]]:
+    """
+    Split molecule names into `num_jobs` balanced batches.
+
+    Args:
+        molecules (List[str]): List of molecule identifiers.
+        num_jobs (int): Number of batches/jobs desired.
+
+    Returns:
+        List[List[str]]: List of molecule batches.
+    """
+    total_mols = len(molecules)
+    if num_jobs > total_mols:
+        logging.info("More jobs than molecules. Launching one job per molecule.")
+        return [[mol] for mol in molecules]
+
+    k, m = divmod(total_mols, num_jobs)
+    return [
+        molecules[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
+        for i in range(num_jobs)
+    ]
+
+
+def write_yaml(
+    yaml_path: Path, args: argparse.Namespace, protein_target_path: str, ligand_path: str
+) -> None:
+    """
+    Write a YAML configuration file for OpenDUck.
+
+    Args:
+        yaml_path (Path): Full path where the YAML file is to be written.
+        args (argparse.Namespace): Parsed command-line arguments.
+        protein_target_path (str): Relative path to the protein file from the job directory.
+        ligand_path (str): Relative path to the ligand file from the job directory.
+    """
+    config: Dict[str, object] = {
+        "interaction": args.interaction,
+        "receptor_pdb": protein_target_path,
+        "ligand_mol": ligand_path,
+        "threads": args.cores,
+        "small_molecule_forcefield": args.small_molecule_forcefield,
+        "protein_forcefield": args.protein_forcefield,
+        "water_model": args.water_model,
+        "HMR": args.HMR,
+        "smd_cycles": args.smd_cycles,
+    }
+
+    if args.wqb_threshold is not None:
+        config["wqb_threshold"] = args.wqb_threshold
+    if args.ionic_strength:
+        config["ionic_strength"] = args.ionic_strength
+    if args.gpu:
+        config["gpu_id"] = 0
+    if args.fix_ligand:
+        config["fix_ligand"] = True
+    if args.do_chunk:
+        config["do_chunk"] = True
+        config["cutoff"] = args.cutoff
+
+    with open(yaml_path, "w") as f:
+        yaml.dump(config, f, sort_keys=False)
+
+
+def main() -> None:
+    """
+    Main function that manages the SLURM job generation process.
+    """
+    args = parse_arguments()
+
+    # Set default cores if not explicitly provided.
+    if args.cores is None:
+        args.cores = 1 if args.gpu else 8
+
+    queue_arg = build_slurm_flag("partition", args.queue)
+    time_arg = build_slurm_flag("time", args.time)
+
+    # Validate input file/directory
+    if not args.ligand.exists():
+        raise FileNotFoundError(f"Ligand path does not exist: {args.ligand}")
+    if not args.protein.exists():
+        raise FileNotFoundError(f"Protein file does not exist: {args.protein}")
+    if not args.protein.is_file() or args.protein.suffix.lower() != ".pdb":
+        raise ValueError(f"Protein file must be a .pdb file: {args.protein}")
+
+    # Process ligand molecules from file or directory
+    mol_dict: Dict[str, Chem.Mol] = {}
+    total_invalid_mols: int = 0
+    if args.ligand.is_file():
+        mol_dict, total_invalid_mols = process_sdf(args.ligand)
+    elif args.ligand.is_dir():
+        for ligand_file in glob.glob(str(args.ligand / "*.sdf")):
+            single_dict, invalid_count = process_sdf(Path(ligand_file))
+            mol_dict.update(single_dict)
+            total_invalid_mols += invalid_count
+    else:
+        raise ValueError("Ligand path must be a file or directory.")
+
+    logging.info("Identified %d valid compounds, %d invalid", len(mol_dict), total_invalid_mols)
+
+    # Prepare the output directory and copy the protein file there
+    output_dir: Path = prepare_output_directory(args.output)
+    protein_target_path: str = shutil.copy(str(args.protein), str(output_dir))
+
+    # Decide on job batching
+    if args.jobs <= 0 or args.jobs > len(mol_dict):
+        args.jobs = len(mol_dict)
+        logging.info("Launching one job per compound...")
+
+    one_mol_per_job: bool = args.jobs == len(mol_dict)
+    batches: List[List[str]] = batch_mols(list(mol_dict.keys()), args.jobs)
+
+    singularity_path: Path = Path("openDUck.sif").resolve()
+
+    # Generate job directories and scripts
+    for idx, mol_batch in enumerate(batches, start=1):
+        if one_mol_per_job:
+            safe_mol_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in mol_batch[0])
+            folder_name = f"{idx}_{safe_mol_name}"
+        else:
+            folder_name = f"{idx}_batch_mols"
+
+        job_dir: Path = output_dir / folder_name
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        relative_protein_path: str = os.path.relpath(protein_target_path, job_dir)
+
+        # Write SDF file for ligand molecules in this batch
+        sdf_name: str = f"input_mol_job_{idx}.sdf"
+        sdf_path: Path = job_dir / sdf_name
+        with Chem.SDWriter(str(sdf_path)) as writer:
+            for mol_id in mol_batch:
+                writer.write(mol_dict[mol_id])
+
+        # Write YAML configuration file
+        yaml_filename: str = f"input_protocol_job_{idx}.yaml"
+        yaml_path: Path = job_dir / yaml_filename
+        write_yaml(
+            yaml_path=yaml_path,
+            args=args,
+            protein_target_path=str(relative_protein_path),
+            ligand_path=sdf_name,
+        )
+
+        # Construct common SLURM arguments and job command
+        common_slurm_args: str = (
+            f"--mem {args.mem} --output=job_{idx}_%j.out --job-name=openDUck_{idx} -c {args.cores} {time_arg} {queue_arg}"
+        ).strip()
+
+        gpu_flag: str = "--nv " if args.gpu else ""
+        run_command: str = (
+            f"OPENMM_CPU_THREADS={args.cores} singularity exec {gpu_flag}--bind $PWD {singularity_path} "
+            f"openduck openmm-full-protocol -y {yaml_filename}"
+        )
+        job_cmd: str = f'sbatch --chdir "{job_dir}" --wrap="{run_command}"'
+        if args.gpu:
+            job_cmd += " --gres=gpu:1"
+        job_cmd += f" {common_slurm_args}"
+
+        # Write the job script to file
+        job_script_path: Path = job_dir / f"job_{idx}.sh"
+        with open(job_script_path, "w") as jobfile:
+            jobfile.write("#!/usr/bin/env bash\n")
+            jobfile.write(job_cmd + "\n")
+
+    launch_cmd = f'for f in {str(output_dir)}/*/job_*.sh; do sh "$f"; done'
+    
+    # Write final launcher of all jobs
+    with open(f"{output_dir}/launch_jobs.sh", "w") as job_launch_file:
+        job_launch_file.write("#!/usr/bin/env bash\n")    
+        job_launch_file.write(f"{launch_cmd}\n")
+    
+    # Check if sbatch command is available
+    if shutil.which("sbatch") is not None:
+        subprocess.run(launch_cmd, shell=True)
+    else:
+        logging.warning(f"The sbatch command doesn't seem to be available. Try to launch the jobs manually (without Singularity) by running:\nsh {output_dir}/launch_jobs.sh")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logging.exception("An error occurred during job generation: %s", e)
+        sys.exit(1)

--- a/scripts/openmm_job_launcher.py
+++ b/scripts/openmm_job_launcher.py
@@ -58,6 +58,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "-p",
         "--protein",
+        "-r",
+        "--receptor",
         type=Path,
         required=True,
         help="Path to the receptor protein .pdb file.",
@@ -127,7 +129,7 @@ def parse_arguments() -> argparse.Namespace:
     # OpenDUck protocol settings
     duck_group = parser.add_argument_group("OpenDUck Protocol Settings")
     duck_group.add_argument(
-        "--interaction",
+        "--interaction", "-i",
         type=str,
         required=True,
         help="Interaction atom (e.g., _LEU_31_N).",
@@ -232,7 +234,6 @@ def resolve_singularity_image(user_arg: Optional[str]) -> Optional[Path]:
 
     # --singularity flag was used
     if user_arg:
-        check_singularity_available()
 
         if user_arg == "AUTO":
             if default_img.exists():
@@ -537,13 +538,13 @@ def main() -> None:
         if singularity_path:
             gpu_flag = "--nv " if args.gpu else ""
             run_command = (
-                f"OPENMM_CPU_THREADS={args.cores} "
+                f"PYTHONUNBUFFERED=1 OPENMM_CPU_THREADS={args.cores} "
                 f"singularity exec {gpu_flag}--bind $PWD {singularity_path} "
                 f"openduck openmm-full-protocol -y {yaml_filename}"
             )
         else:
             run_command = (
-                f"OPENMM_CPU_THREADS={args.cores} "
+                f"PYTHONUNBUFFERED=1 OPENMM_CPU_THREADS={args.cores} "
                 f"openduck openmm-full-protocol -y {yaml_filename}"
             )
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
     entry_points={
         "console_scripts": [
             "openduck=scripts.openduck:main",
+            "openmm_job_launcher=scripts.openmm_job_launcher:main",
         ]
     },
 )


### PR DESCRIPTION
This PR adds batch support for the OpenMM backend, as discussed in #31.

In addition, I've implemented a new launcher script to easily distribute OpenMM calculations across SLURM jobs.
The launcher also supports running via Singularity containers (I included a Singularity definition file so a container can be built too), making it flexible across different HPC setups.

I think this makes launching jobs for many ligands much easier, and more scalable.
Since this is based on the OpenMM backend, it supports both CPU and GPU execution, and can efficiently use many CPU cores or GPUs.

The launcher script has also been registered as a proper CLI command (`openmm_job_launcher`) by updating `setup.py`.
This means users can now run it directly from the terminal without needing to manually call the script file.

If you agree with the added features here, perhaps the main README should be updated to document this new functionality more visibly — happy to include that in this PR if desired. The `--help` command should already be very informative for now though.

If possible, it would be great if you could try it yourself with a test example.
I ran multiple tests on my side, and everything seems to work as expected, but of course I could have overlooked some things.

Thanks a lot for your time and review!

Best,
Jochem

P.S.: Commit 39e7263f4f0003902ee931ef1a951e1b0439c2f1 changed the report script to use numpy instead of the regular python math functions. I was facing troubles with overflows, but resorting to use numpy fixed it. It can be reverted if you think that's better